### PR TITLE
do not edit data array when loading departments table

### DIFF
--- a/src/components/departments-table.js
+++ b/src/components/departments-table.js
@@ -99,7 +99,8 @@ const rowClasses = (row, rowIndex) => {
 
 const Table = ({data}) => {
   const firstRow = createFirstRow(data);
-  data.unshift(firstRow);
+  // creates new array
+  data = data.concat([firstRow]);
   return (
     <ToolkitProvider
       keyField="code"


### PR DESCRIPTION
This fixes the bug when the `Totals for All Departments` row would appear on every render of the departments page.