### PR TITLE
fixed Windows compatibility with node-sass plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
         {
           resolve: 'gatsby-plugin-sass',
           options: {
-            data: `@import "${__dirname}/src/styles/_variables.scss";`,
+            data: `@import "./src/styles/_variables.scss";`,
           }
         },
         `gatsby-plugin-react-helmet`,


### PR DESCRIPTION
${__dirname} didn't work in Windows