### PR TITLE
Handle case of 0 staff

### DIFF
--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -60,15 +60,21 @@ const CentralProgram = ({ data }) => {
                 <h2 className="pb-3 pt-sm-3 pt-md-2">{`Staff Roles (${data.site.siteMetadata.latestSchoolYear})`}</h2>
                 <StaffRolesTable data={centralProgram.staff_roles} />
               </div>
-              <div id={`${ELEMENT_NAME_PREFIX}-2`} className="pt-4">
-                <h2 className="pb-3">{`Staff Labor Unions (${data.site.siteMetadata.latestSchoolYear})`}</h2>
-                <StaffLaborUnionsChart
-                  data={centralProgram.staff_bargaining_units}
-                />
-                <StaffLaborUnionsTable
-                  data={centralProgram.staff_bargaining_units}
-                />
-              </div>
+              {/* if staff_bargaining_units array is 0 length or 0 value
+                return Staff Labor Union section null
+              */}
+              {centralProgram.staff_bargaining_units.length === 0 ||
+                centralProgram.staff_bargaining_units.includes(0) ? null : (
+                  <div id={`${ELEMENT_NAME_PREFIX}-2`} className="pt-4">
+                    <h2 className="pb-3">{`Staff Labor Unions (${data.site.siteMetadata.latestSchoolYear})`}</h2>
+                    <StaffLaborUnionsChart
+                      data={centralProgram.staff_bargaining_units}
+                    />
+                    <StaffLaborUnionsTable
+                      data={centralProgram.staff_bargaining_units}
+                    />
+                  </div>
+                )}
             </Col>
           </Row>
         </Container>

--- a/src/components/table-utilities.js
+++ b/src/components/table-utilities.js
@@ -11,13 +11,13 @@ export const getSortCaret = (order, column) => {
   }
   // invisible icon used as a spaceholder so that
   // when an icon does render it does not shift the table column
-  return (<ArrowDropDown className="invisible"/>)
+  return (<ArrowDropDown className="invisible" />)
 }
 
 export const formatToUSD = amount => {
   // it would be better to just useIntl.NumberFormat currency, but that seems to always
   // add cents ie $2,330.00
-  return '$' + new Intl.NumberFormat('en-US', { maximumFractionDigits: 0}).format(amount)
+  return '$' + new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(amount)
 }
 
 
@@ -38,11 +38,7 @@ export const sort = (a, b, order, dataField, rowA, rowB, firstColDatafield, tota
   return 0
 }
 
-export const formatFTE = (fte) => {
-  if(fte){
-    // Round but don't add trailing zeroes
-    fte = +fte.toFixed(2)
-  }
 
-  return fte
-}
+
+// Convert null to zero & Round without trailing zeroes
+export const formatFTE = fte => (!fte ? 0 : +fte.toFixed(2))


### PR DESCRIPTION
Howdy, 

In the Staff section of the overview table, I changed 0 staff instead of null.

Hide the Staff Labor Unions section when staff is 0 length or 0 value.

Looks like my linter did minor changes to some returns, nothing breaking and doesn't affect readability.