### PR TITLE
Use Contentful to power funding sources & central programs tables

### DIFF
--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -11,17 +11,47 @@ import SEO from "../components/seo"
 
 import "../styles/pages/about-categories.scss"
 
-const AboutCategoriesPage = ({ data }) => {
+const AboutCategoriesPage = ({ data, pageContext }) => {
   const [key, setKey] = useState("funding-sources")
 
+  const {language: nodeLocale} = pageContext
   const {
     allCentralProgramsJson,
     allCentralProgramsResourcesJson,
+    allContentfulCentralProgramCategory,
+    allContentfulFundingSourceCategory,
     contentfulPage,
   } = data
 
-  const expenditureCategories = allCentralProgramsJson.nodes
-  const revenueCategories = allCentralProgramsResourcesJson.nodes
+  
+  const localizeCategory = (row, contentfulNodes) => {
+    let localizedCategory = row.category;
+
+    // If we're in a locality other than English, use the fetched English category name to find the corresponding Contentful node in the English locale,
+    // and then use the ID of that Contentful node to find the localized category name by looking up the Contentful node by ID for the given node locale.
+    // This is kind of hacky, but was the quickest way forward given that we don't currently store category IDs in the database.
+    if (nodeLocale !== 'en') {
+      const englishNode = contentfulNodes.find(node => node.categoryName === row.category && node.node_locale === 'en')
+      if (!englishNode) {
+        console.log(`No category found in Contentful with English name ${row.category}; displaying name in English`)
+      } else {
+        const localizedNode = contentfulNodes.find(node => node.contentful_id === englishNode.contentful_id && node.node_locale === nodeLocale)
+        if (!localizedNode) {
+          console.log(`No category found in Contentful with ID ${englishNode.category_id} for node locale ${nodeLocale}; displaying name in English`)
+        } else {
+          localizedCategory = localizedNode.categoryName
+        }
+      }
+    }
+
+    return {
+      ...row,
+      category: localizedCategory
+    }
+  }
+
+  const expenditureCategories = allCentralProgramsJson.nodes.map(node => localizeCategory(node, allContentfulCentralProgramCategory.nodes))
+  const revenueCategories = allCentralProgramsResourcesJson.nodes.map(node => localizeCategory(node, allContentfulFundingSourceCategory.nodes))
 
   const {
     introText,
@@ -131,6 +161,20 @@ export default AboutCategoriesPage
 // https://app.contentful.com/spaces/tqd0xcamk1ij/entries/6ETIpT6w1rcLlITOAjZU0y
 export const query = graphql`
   query AboutCategoriesPage($language: String) {
+    allContentfulCentralProgramCategory {
+      nodes {
+        categoryName
+        node_locale
+        contentful_id
+      }
+    }
+    allContentfulFundingSourceCategory {
+      nodes {
+        categoryName
+        node_locale
+        contentful_id
+      }
+    }
     contentfulPage(
       slug: { eq: "about-categories" }
       node_locale: { eq: $language }


### PR DESCRIPTION
This PR powers the funding sources & central programs tables in the "About: Categories" page using Contentful to support multiple node locales. Implemented using the Option A approach in this doc (thanks John!): https://docs.google.com/document/d/1va92sLZq91KpEzOzjrsdtOEp_WFV5FliwNg-DGbtA88

English:
<img src="https://user-images.githubusercontent.com/4400233/101587072-357b0900-3998-11eb-833b-e8bffb0306d4.png" width="40%"/><img src="https://user-images.githubusercontent.com/4400233/101587086-3f047100-3998-11eb-82ee-6e72e2eb754f.png" width="40%"/>

Spanish:
<img src="https://user-images.githubusercontent.com/4400233/101587106-4c216000-3998-11eb-81e1-0e1e7b98af96.png" width="40%"/><img src="https://user-images.githubusercontent.com/4400233/101587122-56435e80-3998-11eb-9bef-8985cbcb1637.png" width="40%"/>

