### PR TITLE
Translate central programs page

### DIFF
--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -9,12 +9,14 @@ import CategoriesTable from "../components/categories-table"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
+import { localizeCategory } from "../utilities/content-utilities"
+
 import "../styles/pages/about-categories.scss"
 
 const AboutCategoriesPage = ({ data, pageContext }) => {
   const [key, setKey] = useState("funding-sources")
 
-  const {language: nodeLocale} = pageContext
+  const { language: nodeLocale } = pageContext
   const {
     allCentralProgramsJson,
     allCentralProgramsResourcesJson,
@@ -23,35 +25,26 @@ const AboutCategoriesPage = ({ data, pageContext }) => {
     contentfulPage,
   } = data
 
-  
-  const localizeCategory = (row, contentfulNodes) => {
-    let localizedCategory = row.category;
-
-    // If we're in a locality other than English, use the fetched English category name to find the corresponding Contentful node in the English locale,
-    // and then use the ID of that Contentful node to find the localized category name by looking up the Contentful node by ID for the given node locale.
-    // This is kind of hacky, but was the quickest way forward given that we don't currently store category IDs in the database.
-    if (nodeLocale !== 'en') {
-      const englishNode = contentfulNodes.find(node => node.categoryName === row.category && node.node_locale === 'en')
-      if (!englishNode) {
-        console.log(`No category found in Contentful with English name ${row.category}; displaying name in English`)
-      } else {
-        const localizedNode = contentfulNodes.find(node => node.contentful_id === englishNode.contentful_id && node.node_locale === nodeLocale)
-        if (!localizedNode) {
-          console.log(`No category found in Contentful with ID ${englishNode.category_id} for node locale ${nodeLocale}; displaying name in English`)
-        } else {
-          localizedCategory = localizedNode.categoryName
-        }
-      }
-    }
-
+  const expenditureCategories = allCentralProgramsJson.nodes.map(node => {
     return {
-      ...row,
-      category: localizedCategory
+      ...node,
+      category: localizeCategory(
+        node.category,
+        allContentfulCentralProgramCategory.nodes,
+        nodeLocale
+      ),
     }
-  }
-
-  const expenditureCategories = allCentralProgramsJson.nodes.map(node => localizeCategory(node, allContentfulCentralProgramCategory.nodes))
-  const revenueCategories = allCentralProgramsResourcesJson.nodes.map(node => localizeCategory(node, allContentfulFundingSourceCategory.nodes))
+  })
+  const revenueCategories = allCentralProgramsResourcesJson.nodes.map(node => {
+    return {
+      ...node,
+      category: localizeCategory(
+        node.category,
+        allContentfulFundingSourceCategory.nodes,
+        nodeLocale
+      ),
+    }
+  })
 
   const {
     introText,

--- a/src/pages/central-programs.js
+++ b/src/pages/central-programs.js
@@ -21,7 +21,7 @@ const CentralProgramsPage = ({ data, pageContext }) => {
   let centralPrograms = data.allCentralProgramsJson.nodes
   const content = data.contentfulPage.content
   const translatedProgramNames = data.allContentfulCentralProgram.nodes
-  const categoryLocalizations = [
+  const translatedCategories = [
     ...data.allContentfulCentralProgramCategory.nodes,
     ...data.allContentfulFundingSourceCategory.nodes,
   ]
@@ -38,7 +38,7 @@ const CentralProgramsPage = ({ data, pageContext }) => {
     }
     program.category = localizeCategory(
       program.category,
-      categoryLocalizations,
+      translatedCategories,
       nodeLocale
     )
     return program
@@ -49,7 +49,7 @@ const CentralProgramsPage = ({ data, pageContext }) => {
     for (let field of fields) {
       localizedObject[field] = localizeCategory(
         object[field],
-        categoryLocalizations,
+        translatedCategories,
         nodeLocale
       )
     }

--- a/src/pages/central-programs.js
+++ b/src/pages/central-programs.js
@@ -21,6 +21,11 @@ const CentralProgramsPage = ({ data, pageContext }) => {
   let centralPrograms = data.allCentralProgramsJson.nodes
   const content = data.contentfulPage.content
   const translatedProgramNames = data.allContentfulCentralProgram.nodes
+  const categoryLocalizations = [
+    ...data.allContentfulCentralProgramCategory.nodes,
+    ...data.allContentfulFundingSourceCategory.nodes,
+  ]
+  const { language: nodeLocale } = pageContext
 
   centralPrograms = centralPrograms.map(program => {
     try {
@@ -31,14 +36,13 @@ const CentralProgramsPage = ({ data, pageContext }) => {
       console.warn(`Could not find Contentful translation for ${program.name}`)
       // throw new Error(`Could not find Contentful translation for ${program.name}`)
     }
+    program.category = localizeCategory(
+      program.category,
+      categoryLocalizations,
+      nodeLocale
+    )
     return program
   })
-
-  const categoryLocalizations = [
-    ...data.allContentfulCentralProgramCategory.nodes,
-    ...data.allContentfulFundingSourceCategory.nodes,
-  ]
-  const { language: nodeLocale } = pageContext
 
   const localizeFields = (fields, object) => {
     const localizedObject = { ...object }

--- a/src/pages/central-programs.js
+++ b/src/pages/central-programs.js
@@ -13,23 +13,56 @@ import SankeyChart from "../components/sankey-chart"
 import sankeyProgramData from "../../data/sankey.json"
 import sankeyRestrictedProgramData from "../../data/sankey-restricted.json"
 
+import { localizeCategory } from "../utilities/content-utilities"
+
 import "../components/sankey-chart.scss"
 
-const CentralProgramsPage = ({ data }) => {
+const CentralProgramsPage = ({ data, pageContext }) => {
   let centralPrograms = data.allCentralProgramsJson.nodes
   const content = data.contentfulPage.content
   const translatedProgramNames = data.allContentfulCentralProgram.nodes
 
   centralPrograms = centralPrograms.map(program => {
     try {
-      program.name = translatedProgramNames.find(t => t.siteCode === program.code).programName
-    }
-    catch(e) {
+      program.name = translatedProgramNames.find(
+        t => t.siteCode === program.code
+      ).programName
+    } catch (e) {
       console.warn(`Could not find Contentful translation for ${program.name}`)
       // throw new Error(`Could not find Contentful translation for ${program.name}`)
     }
     return program
   })
+
+  const categoryLocalizations = [
+    ...data.allContentfulCentralProgramCategory.nodes,
+    ...data.allContentfulFundingSourceCategory.nodes,
+  ]
+  const { language: nodeLocale } = pageContext
+
+  const localizeFields = (fields, object) => {
+    const localizedObject = { ...object }
+    for (let field of fields) {
+      localizedObject[field] = localizeCategory(
+        object[field],
+        categoryLocalizations,
+        nodeLocale
+      )
+    }
+    return localizedObject
+  }
+
+  const localizeSankeyData = ({ nodes, links }) => {
+    return {
+      nodes: nodes.map(localizeFields.bind(null, ["id"])),
+      links: links.map(localizeFields.bind(null, ["target", "source"])),
+    }
+  }
+
+  const translatedSankeyProgramData = localizeSankeyData(sankeyProgramData)
+  const translatedSankeyRestrictedProgramData = localizeSankeyData(
+    sankeyRestrictedProgramData
+  )
 
   return (
     <Layout pageClassName="central-programs-page">
@@ -46,8 +79,8 @@ const CentralProgramsPage = ({ data }) => {
       </Container>
       <RequireWideScreen minScreenWidth={"sm"}>
         <SankeyChart
-          data={sankeyProgramData}
-          restrictedData={sankeyRestrictedProgramData}
+          data={translatedSankeyProgramData}
+          restrictedData={translatedSankeyRestrictedProgramData}
           labelContent={content.spendingSankeyChart}
           margin={{ top: 50, right: 200, bottom: 20, left: 240 }}
           gaEventCategory="Overview"
@@ -80,12 +113,12 @@ export const query = graphql`
         latestSchoolYear
       }
     }
-    allContentfulCentralProgram(filter: {node_locale: {eq: $language}}) {
+    allContentfulCentralProgram(filter: { node_locale: { eq: $language } }) {
       nodes {
         programName
         siteCode
       }
-  	}
+    }
     allCentralProgramsJson {
       nodes {
         name
@@ -99,6 +132,20 @@ export const query = graphql`
         fields {
           slug
         }
+      }
+    }
+    allContentfulCentralProgramCategory {
+      nodes {
+        categoryName
+        node_locale
+        contentful_id
+      }
+    }
+    allContentfulFundingSourceCategory {
+      nodes {
+        categoryName
+        node_locale
+        contentful_id
       }
     }
 

--- a/src/pages/central-programs.js
+++ b/src/pages/central-programs.js
@@ -44,7 +44,7 @@ const CentralProgramsPage = ({ data, pageContext }) => {
     return program
   })
 
-  const localizeFields = (fields, object) => {
+  const localizeCategoryFields = (fields, object) => {
     const localizedObject = { ...object }
     for (let field of fields) {
       localizedObject[field] = localizeCategory(
@@ -58,8 +58,8 @@ const CentralProgramsPage = ({ data, pageContext }) => {
 
   const localizeSankeyData = ({ nodes, links }) => {
     return {
-      nodes: nodes.map(localizeFields.bind(null, ["id"])),
-      links: links.map(localizeFields.bind(null, ["target", "source"])),
+      nodes: nodes.map(localizeCategoryFields.bind(null, ["id"])),
+      links: links.map(localizeCategoryFields.bind(null, ["target", "source"])),
     }
   }
 

--- a/src/utilities/content-utilities.js
+++ b/src/utilities/content-utilities.js
@@ -7,3 +7,36 @@ export const getColumnsByDataField = columns => {
 
 	return columnLabelsByDatafield
 }
+
+export const localizeCategory = (category, contentfulNodes, nodeLocale) => {
+	let localizedCategory = category
+
+	// If we're in a locality other than English, use the fetched English category name to find the corresponding Contentful node in the English locale,
+	// and then use the ID of that Contentful node to find the localized category name by looking up the Contentful node by ID for the given node locale.
+	// This is kind of hacky, but was the quickest way forward given that we don't currently store category IDs in the database.
+	if (nodeLocale !== "en") {
+		const englishNode = contentfulNodes.find(
+			node => node.categoryName === category && node.node_locale === "en"
+		)
+		if (!englishNode) {
+			console.log(
+				`No category found in Contentful with English name ${category}; displaying name in English`
+			)
+		} else {
+			const localizedNode = contentfulNodes.find(
+				node =>
+					node.contentful_id === englishNode.contentful_id &&
+					node.node_locale === nodeLocale
+			)
+			if (!localizedNode) {
+				console.log(
+					`No category found in Contentful with ID ${englishNode.category_id} for node locale ${nodeLocale}; displaying name in English`
+				)
+			} else {
+				localizedCategory = localizedNode.categoryName
+			}
+		}
+	}
+
+	return localizedCategory
+}


### PR DESCRIPTION
Moved Emily's work to the content-utilities file and used it to translate the categories on the central programs  page.

Restricted and Unrestricted are not translated, maybe add them as categories in contentful?

Also there doesn't seem to be a localization for General (base).

Sankey Diagram English
![Screenshot from 2020-12-15 19-54-22](https://user-images.githubusercontent.com/52506986/102303392-ea20a780-3f0f-11eb-923c-9547e7a2b318.png)
![Screenshot from 2020-12-15 19-54-24](https://user-images.githubusercontent.com/52506986/102303393-ebea6b00-3f0f-11eb-993a-81b80f8d4d70.png)

Sankey Diagram Spanish
![Screenshot from 2020-12-15 19-54-17](https://user-images.githubusercontent.com/52506986/102303379-e42ac680-3f0f-11eb-8655-ed243ea6c833.png)
![Screenshot from 2020-12-15 19-54-12](https://user-images.githubusercontent.com/52506986/102303383-e5f48a00-3f0f-11eb-8538-998570459750.png)

Table English
![Screenshot from 2020-12-15 19-54-33](https://user-images.githubusercontent.com/52506986/102303415-f73d9680-3f0f-11eb-99e6-e9c7126666a5.png)

Table Spanish
![Screenshot from 2020-12-15 19-54-47](https://user-images.githubusercontent.com/52506986/102303420-f99ff080-3f0f-11eb-94ad-1adceffcd8d2.png)

Any critical comments on the code are greatly appreciated!