### PR TITLE
Min column width

### DIFF
--- a/src/components/central-program/program-data-overview-table.js
+++ b/src/components/central-program/program-data-overview-table.js
@@ -80,6 +80,7 @@ const SpendingOverview = ({ data }) => {
           <div className="text-right value">{formatToUSD(data[SPENDING])}</div>
         )
       },
+      headerStyle: { minWidth: "10em" },
     },
   ]
 
@@ -199,6 +200,7 @@ const StaffOverview = ({ data }) => {
       dataField: VALUE,
       align: "right",
       text: "",
+      headerStyle: { minWidth: "6em" },
     },
   ]
 


### PR DESCRIPTION
Setting a minimum column width on the program details page because text was wrapping on mobile
<img width="402" alt="Screen Shot 2020-12-20 at 11 08 55 AM" src="https://user-images.githubusercontent.com/1191015/102722117-d41a3a80-42b3-11eb-96c5-c9a855a16f6b.png">
