### PR TITLE
Use fragments on central component queries

### DIFF
--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -36,13 +36,14 @@ const CentralProgram = ({ data }) => {
               <h1>{translatedProgramName}</h1>
               <div id={`${ELEMENT_NAME_PREFIX}-0`} className="pt-4">
                 <h2>
-                  {content.programOverviewTable.heading}{" "}
-                  ({data.site.siteMetadata.latestSchoolYear})
+                  {content.programOverviewTable.heading} (
+                  {data.site.siteMetadata.latestSchoolYear})
                 </h2>
                 <ProgramDataOverviewTable
                   data={data}
                   content={content.programOverviewTable}
-                  className="pt-2" />
+                  className="pt-2"
+                />
               </div>
             </Col>
           </Row>
@@ -67,7 +68,8 @@ const CentralProgram = ({ data }) => {
                 </h2>
                 <StaffRolesTable
                   data={centralProgram.staff_roles}
-                  content={content.staffRolesTable} />
+                  content={content.staffRolesTable}
+                />
               </div>
               {/* if staff_bargaining_units array is 0 length or 0 value
                 return Staff Labor Union section null
@@ -100,33 +102,16 @@ export const query = graphql`
         latestSchoolYear
       }
     }
-    contentfulCentralProgram(siteCode: {eq: $code}, node_locale: {eq: $language}) {
+    contentfulCentralProgram(
+      siteCode: { eq: $code }
+      node_locale: { eq: $language }
+    ) {
       programName
     }
     centralProgramsJson(code: { eq: $code }) {
-      name
-      budget
-      remaining_budget_percent
-      eoy_total_fte
-      eoy_total_positions
-      spending
-      year
-      code
-      staff_roles {
-        eoy_total_positions_for_role
-        role_description
-      }
-      staff_bargaining_units {
-        eoy_total_positions_for_bu
-        bargaining_unit_name
-        abbreviation
-      }
-      change_from_previous_year {
-        budget
-        eoy_total_fte
-        eoy_total_positions
-        spending
-      }
+      ...ProgramOverviewData
+      ...StaffRolesData
+      ...StaffLaborUnionsData
     }
     centralProgramsSankeyJson(site_code: { eq: $code }) {
       nodes {
@@ -140,30 +125,15 @@ export const query = graphql`
         value
       }
     }
-    contentfulPage(slug: {eq: "central-programs/*"}, node_locale: {eq: $language}) {
+    contentfulPage(
+      slug: { eq: "central-programs/*" }
+      node_locale: { eq: $language }
+    ) {
       content {
         ... on ContentfulProgramDetailsPageTemplate {
-          programOverviewTable {
-            columns {
-              displayName
-              dataFieldName
-            }
-            heading
-          }
-          staffLaborUnionsTable {
-            columns {
-              displayName
-              dataFieldName
-            }
-            heading
-          }
-          staffRolesTable {
-            columns {
-              displayName
-              dataFieldName
-            }
-            heading
-          }
+          ...ProgramOverviewContent
+          ...StaffLaborUnionsContent
+          ...StaffRolesContent
         }
       }
     }

--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -109,8 +109,10 @@ export const query = graphql`
         abbreviation
       }
       change_from_previous_year {
+        budget
         eoy_total_fte
         eoy_total_positions
+        spending
       }
     }
     centralProgramsSankeyJson(site_code: { eq: $code }) {

--- a/src/components/central-program/program-data-overview-table.js
+++ b/src/components/central-program/program-data-overview-table.js
@@ -271,6 +271,34 @@ const ProgramDataOverviewTable = ({ data, content, className }) => {
   )
 }
 
+export const query = graphql`
+  fragment ProgramOverviewContent on ContentfulProgramDetailsPageTemplate {
+    programOverviewTable {
+      columns {
+        displayName
+        dataFieldName
+      }
+      heading
+    }
+  }
+  fragment ProgramOverviewData on CentralProgramsJson {
+    name
+    budget
+    remaining_budget_percent
+    eoy_total_fte
+    eoy_total_positions
+    spending
+    year
+    code
+    change_from_previous_year {
+      budget
+      eoy_total_fte
+      eoy_total_positions
+      spending
+    }
+  }
+`
+
 ProgramDataOverviewTable.propTypes = {
   data: PropTypes.object,
 }

--- a/src/components/central-program/program-data-overview-table.js
+++ b/src/components/central-program/program-data-overview-table.js
@@ -54,6 +54,7 @@ const SpendingOverview = ({ data }) => {
     {
       dataField: "value",
       text: "Value",
+      align: "right",
       headerFormatter: (column, colIndex, components) => {
         return (
           <div className="text-right value">{formatToUSD(data.spending)}</div>
@@ -62,10 +63,23 @@ const SpendingOverview = ({ data }) => {
     },
   ]
 
+  const rows = []
+
+  if (data.change_from_previous_year) {
+    const spending_delta = data.change_from_previous_year.spending
+
+    rows.push({
+      description: "Change in spending from previous year",
+      value: `${deltaPrefix(spending_delta)}${formatToUSD(
+        Math.abs(spending_delta)
+      )}`,
+    })
+  }
+
   return (
     <ToolkitProvider
       keyField="description"
-      data={[]}
+      data={rows}
       columns={columns}
       bootstrap4
     >
@@ -103,6 +117,19 @@ const BudgetOverview = ({ data }) => {
     },
   ]
 
+  const rows = []
+
+  if (data.change_from_previous_year) {
+    const budget_delta = data.change_from_previous_year.budget
+
+    rows.push({
+      description: "Change in budget from previous year",
+      value: `${deltaPrefix(budget_delta)}${formatToUSD(
+        Math.abs(budget_delta)
+      )}`,
+    })
+  }
+
   let overOrUnder = "Over",
     difference
   if (data.spending > data.budget) {
@@ -112,14 +139,12 @@ const BudgetOverview = ({ data }) => {
     difference = data.budget - data.spending
   }
 
-  const rows = [
-    {
-      description: "Over or under budget?",
-      value: `${overOrUnder} by ${formatToUSD(difference)} (${Math.abs(
-        data.remaining_budget_percent
-      )}%)`,
-    },
-  ]
+  rows.push({
+    description: "Over or under budget?",
+    value: `${overOrUnder} by ${formatToUSD(difference)} (${Math.abs(
+      data.remaining_budget_percent
+    )}%)`,
+  })
 
   return (
     <ToolkitProvider
@@ -153,7 +178,7 @@ const StaffOverview = ({ data }) => {
     {
       dataField: "value",
       align: "right",
-      text: ""
+      text: "",
     },
   ]
 

--- a/src/components/central-program/staff-labor-unions-table.js
+++ b/src/components/central-program/staff-labor-unions-table.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 import BootstrapTable from "react-bootstrap-table-next"
 import ToolkitProvider from "react-bootstrap-table2-toolkit"
@@ -69,6 +70,25 @@ const StaffLaborUnionsTable = ({ data, content }) => {
     </ToolkitProvider>
   )
 }
+
+export const query = graphql`
+  fragment StaffLaborUnionsContent on ContentfulProgramDetailsPageTemplate {
+    staffLaborUnionsTable {
+      columns {
+        displayName
+        dataFieldName
+      }
+      heading
+    }
+  }
+  fragment StaffLaborUnionsData on CentralProgramsJson {
+    staff_bargaining_units {
+      eoy_total_positions_for_bu
+      bargaining_unit_name
+      abbreviation
+    }
+  }
+`
 
 StaffLaborUnionsTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/central-program/staff-roles-table.js
+++ b/src/components/central-program/staff-roles-table.js
@@ -99,6 +99,24 @@ const StaffRolesTable = ({ data, content }) => {
   )
 }
 
+export const query = graphql`
+  fragment StaffRolesContent on ContentfulProgramDetailsPageTemplate {
+    staffRolesTable {
+      columns {
+        displayName
+        dataFieldName
+      }
+      heading
+    }
+  }
+  fragment StaffRolesData on CentralProgramsJson {
+    staff_roles {
+      eoy_total_positions_for_role
+      role_description
+    }
+  }
+`
+
 StaffRolesTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
 }


### PR DESCRIPTION
We talked about moving the responsibility of querying to individual components with static queries and that it could be tricky since they can't use variables. Maybe fragments could work instead?