### PR TITLE
Add program descriptions

### DIFF
--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -31,16 +31,18 @@ const CentralProgram = ({ data }) => {
         <ScrollWidget
           className="scroll-widget"
           sectionIdPrefix={ELEMENT_NAME_PREFIX}
-          numSections={3}
+          numSections={4}
         />
       </div>
       <div className="central-program-page-template">
         <Container>
           <Row>
             <Col md={9} xl={6} className="mx-auto">
-              <h1>{translatedProgramName}</h1>
-              {programDescription}
               <div id={`${ELEMENT_NAME_PREFIX}-0`} className="pt-4">
+                <h1>{translatedProgramName}</h1>
+                {programDescription}
+              </div>
+              <div id={`${ELEMENT_NAME_PREFIX}-1`} className="pt-4">
                 <h2>
                   {content.programOverviewTable.heading} (
                   {data.site.siteMetadata.latestSchoolYear})
@@ -72,7 +74,7 @@ const CentralProgram = ({ data }) => {
         <Container>
           <Row>
             <Col md={9} xl={6} className="mx-auto">
-              <div id={`${ELEMENT_NAME_PREFIX}-1`} className="pt-4 pt-sm-4">
+              <div id={`${ELEMENT_NAME_PREFIX}-2`} className="pt-4 pt-sm-4">
                 <h2 className="pb-3 pt-sm-3 pt-md-2">
                   {`${content.staffRolesTable.heading} (${data.site.siteMetadata.latestSchoolYear})`}
                 </h2>
@@ -86,7 +88,7 @@ const CentralProgram = ({ data }) => {
               */}
               {centralProgram.staff_bargaining_units.length === 0 ||
               centralProgram.staff_bargaining_units.includes(0) ? null : (
-                <div id={`${ELEMENT_NAME_PREFIX}-2`} className="pt-4">
+                <div id={`${ELEMENT_NAME_PREFIX}-3`} className="pt-4">
                   <h2 className="pb-3">{`${content.staffLaborUnionsTable.heading} (${data.site.siteMetadata.latestSchoolYear})`}</h2>
                   <StaffLaborUnionsChart
                     data={centralProgram.staff_bargaining_units}

--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { Container, Row, Col } from "react-bootstrap"
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 
 import StaffRolesTable from "../components/central-program/staff-roles-table"
 import StaffLaborUnionsTable from "../components/central-program/staff-labor-unions-table"
@@ -21,8 +22,8 @@ const ELEMENT_NAME_PREFIX = "program-section"
 const CentralProgram = ({ data }) => {
   const centralProgram = data.centralProgramsJson
   const translatedProgramName = data.contentfulCentralProgram.programName
-  const programDescription =
-    data.contentfulCentralProgram.description?.content[0].content[0].value
+  const contentfulProgramDescription =
+    data.contentfulCentralProgram.description?.json
   const content = data.contentfulPage.content
   return (
     <Layout>
@@ -40,7 +41,7 @@ const CentralProgram = ({ data }) => {
             <Col md={9} xl={6} className="mx-auto">
               <div id={`${ELEMENT_NAME_PREFIX}-0`} className="pt-4">
                 <h1>{translatedProgramName}</h1>
-                {programDescription}
+                {documentToReactComponents(contentfulProgramDescription)}
               </div>
               <div id={`${ELEMENT_NAME_PREFIX}-1`} className="pt-4">
                 <h2>
@@ -120,11 +121,7 @@ export const query = graphql`
     ) {
       programName
       description {
-        content {
-          content {
-            value
-          }
-        }
+        json
       }
     }
     centralProgramsJson(code: { eq: $code }) {

--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -21,6 +21,8 @@ const ELEMENT_NAME_PREFIX = "program-section"
 const CentralProgram = ({ data }) => {
   const centralProgram = data.centralProgramsJson
   const translatedProgramName = data.contentfulCentralProgram.programName
+  const programDescription =
+    data.contentfulCentralProgram.description?.content[0].content[0].value
   const content = data.contentfulPage.content
   return (
     <Layout>
@@ -37,6 +39,7 @@ const CentralProgram = ({ data }) => {
           <Row>
             <Col md={9} xl={6} className="mx-auto">
               <h1>{translatedProgramName}</h1>
+              {programDescription}
               <div id={`${ELEMENT_NAME_PREFIX}-0`} className="pt-4">
                 <h2>
                   {content.programOverviewTable.heading} (
@@ -114,6 +117,13 @@ export const query = graphql`
       node_locale: { eq: $language }
     ) {
       programName
+      description {
+        content {
+          content {
+            value
+          }
+        }
+      }
     }
     centralProgramsJson(code: { eq: $code }) {
       ...ProgramOverviewData


### PR DESCRIPTION
Right now the link to the OUSD site is in a rich text field as the description itself. If the text for the link would be the same for each description it might be better to have another contentful field for that text and then store the link either in another contentful field or just central-programs.json. 

![Screenshot from 2021-01-28 15-23-48](https://user-images.githubusercontent.com/52506986/106211185-22590e00-617d-11eb-9111-6d249f96b2bc.png)
![Screenshot from 2021-01-28 15-23-52](https://user-images.githubusercontent.com/52506986/106211187-238a3b00-617d-11eb-8c7c-6164b42f6d9b.png)
