### PR TITLE
remove programs with 0 spend

### DIFF
--- a/data/central-programs-sankey.json
+++ b/data/central-programs-sankey.json
@@ -199,14 +199,14 @@
     "site_code": 905,
     "nodes": [
       {
-        "id": "State",
-        "type": "resource",
-        "total": 188173.72
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 1115028.66
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 188173.72
       },
       {
         "id": "SUPPLIES",
@@ -236,14 +236,14 @@
     "site_code": 907,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 848015.93
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 717694.27
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 848015.93
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -303,24 +303,24 @@
         "total": 430481.59
       },
       {
-        "id": "Parcel Taxes",
-        "type": "resource",
-        "total": 1161545.76
-      },
-      {
-        "id": "State",
-        "type": "resource",
-        "total": 2479940.44
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 391537.88
       },
       {
+        "id": "Parcel Taxes",
+        "type": "resource",
+        "total": 1161545.76
+      },
+      {
         "id": "Philanthropy / Grants",
         "type": "resource",
         "total": 1536720.41
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 2479940.44
       },
       {
         "id": "Supplemental & Concentration",
@@ -475,9 +475,9 @@
     "site_code": 910,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
+        "id": "Federal",
         "type": "resource",
-        "total": 316492.26
+        "total": 474992.67
       },
       {
         "id": "Philanthropy / Grants",
@@ -485,14 +485,14 @@
         "total": 2026351.42
       },
       {
-        "id": "Federal",
-        "type": "resource",
-        "total": 474992.67
-      },
-      {
         "id": "State",
         "type": "resource",
         "total": 5436009.24
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 316492.26
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -702,24 +702,14 @@
     "site_code": 912,
     "nodes": [
       {
-        "id": "General (Base)",
-        "type": "resource",
-        "total": 169052.91
-      },
-      {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 1426062
-      },
-      {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 1037974.78
-      },
-      {
         "id": "Federal",
         "type": "resource",
         "total": 451190
+      },
+      {
+        "id": "General (Base)",
+        "type": "resource",
+        "total": 169052.91
       },
       {
         "id": "Parcel Taxes",
@@ -727,9 +717,19 @@
         "total": 1025692.31
       },
       {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 1426062
+      },
+      {
         "id": "State",
         "type": "resource",
         "total": 1834854.68
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 1037974.78
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -1061,24 +1061,9 @@
     "site_code": 922,
     "nodes": [
       {
-        "id": "State",
-        "type": "resource",
-        "total": 2565579.73
-      },
-      {
         "id": "Federal",
         "type": "resource",
         "total": 3114474.03
-      },
-      {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 4792511.86
-      },
-      {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 2272481.35
       },
       {
         "id": "General (Base)",
@@ -1089,6 +1074,21 @@
         "id": "Other Revenue",
         "type": "resource",
         "total": 1761431
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 4792511.86
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 2565579.73
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 2272481.35
       },
       {
         "id": "AFTERSCHOOL CUSTODIAL INTERPRO",
@@ -1403,9 +1403,9 @@
     "site_code": 923,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
+        "id": "Federal",
         "type": "resource",
-        "total": 183530.96
+        "total": 1039502.81
       },
       {
         "id": "General (Base)",
@@ -1413,9 +1413,9 @@
         "total": 297347.35
       },
       {
-        "id": "Federal",
+        "id": "Supplemental & Concentration",
         "type": "resource",
-        "total": 1039502.81
+        "total": 183530.96
       },
       {
         "id": "HEALTH & WELFARE CLASSIFIED",
@@ -1537,6 +1537,11 @@
     "site_code": 929,
     "nodes": [
       {
+        "id": "General (Base)",
+        "type": "resource",
+        "total": 255542.37
+      },
+      {
         "id": "Philanthropy / Grants",
         "type": "resource",
         "total": 856498.3
@@ -1545,11 +1550,6 @@
         "id": "Supplemental & Concentration",
         "type": "resource",
         "total": 2109468.07
-      },
-      {
-        "id": "General (Base)",
-        "type": "resource",
-        "total": 255542.37
       },
       {
         "id": "CLERICAL SALARIES",
@@ -1644,14 +1644,14 @@
     "site_code": 933,
     "nodes": [
       {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 173278.88
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 1572645.51
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 173278.88
       },
       {
         "id": "CLASSSUPPT SALARIES STIPENDS",
@@ -1716,14 +1716,14 @@
     "site_code": 936,
     "nodes": [
       {
-        "id": "General (Base)",
-        "type": "resource",
-        "total": 1493094.13
-      },
-      {
         "id": "Bonds",
         "type": "resource",
         "total": 141221.15
+      },
+      {
+        "id": "General (Base)",
+        "type": "resource",
+        "total": 1493094.13
       },
       {
         "id": "HEALTH & WELFARE CLASSIFIED",
@@ -1872,14 +1872,14 @@
     "site_code": 941,
     "nodes": [
       {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 431728.03
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 944587.95
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 431728.03
       },
       {
         "id": "CONSULTANTS",
@@ -1946,14 +1946,9 @@
     "site_code": 944,
     "nodes": [
       {
-        "id": "Philanthropy / Grants",
+        "id": "Federal",
         "type": "resource",
-        "total": 432347.12
-      },
-      {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 1226963.02
+        "total": 453242.81
       },
       {
         "id": "General (Base)",
@@ -1966,19 +1961,24 @@
         "total": 170353.24
       },
       {
+        "id": "Parcel Taxes",
+        "type": "resource",
+        "total": 776928.02
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 432347.12
+      },
+      {
         "id": "State",
         "type": "resource",
         "total": 648764.11
       },
       {
-        "id": "Federal",
+        "id": "Supplemental & Concentration",
         "type": "resource",
-        "total": 453242.81
-      },
-      {
-        "id": "Parcel Taxes",
-        "type": "resource",
-        "total": 776928.02
+        "total": 1226963.02
       },
       {
         "id": "CLERICAL SALARIES",
@@ -2470,14 +2470,9 @@
     "site_code": 954,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
+        "id": "Federal",
         "type": "resource",
-        "total": 479750.4
-      },
-      {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 1267765.48
+        "total": 1750748.09
       },
       {
         "id": "General (Base)",
@@ -2485,14 +2480,19 @@
         "total": 148450.85
       },
       {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 1267765.48
+      },
+      {
         "id": "State",
         "type": "resource",
         "total": 606398.43
       },
       {
-        "id": "Federal",
+        "id": "Supplemental & Concentration",
         "type": "resource",
-        "total": 1750748.09
+        "total": 479750.4
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -2644,14 +2644,14 @@
     "site_code": 958,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 793870.79
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 1083376.24
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 793870.79
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -2711,14 +2711,14 @@
     "site_code": 962,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 141003.21
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 293458.93
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 141003.21
       },
       {
         "id": "SUPV, ADMIN, INSTR COACHES SAL",
@@ -2748,14 +2748,14 @@
     "site_code": 963,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 183252.17
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 283941.63
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 183252.17
       },
       {
         "id": "SUPV, ADMIN, INSTR COACHES SAL",
@@ -2790,14 +2790,14 @@
         "total": 100000
       },
       {
-        "id": "State",
-        "type": "resource",
-        "total": 1504867.58
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 520579.01
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 1504867.58
       },
       {
         "id": "Supplemental & Concentration",
@@ -2862,24 +2862,24 @@
     "site_code": 965,
     "nodes": [
       {
-        "id": "Parcel Taxes",
-        "type": "resource",
-        "total": 149736.09
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 291318.05
       },
       {
-        "id": "Supplemental & Concentration",
+        "id": "Parcel Taxes",
         "type": "resource",
-        "total": 156726.89
+        "total": 149736.09
       },
       {
         "id": "Philanthropy / Grants",
         "type": "resource",
         "total": 295999.91
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 156726.89
       },
       {
         "id": "SUPV, ADMIN, INSTR COACHES SAL",
@@ -2909,9 +2909,9 @@
     "site_code": 968,
     "nodes": [
       {
-        "id": "Supplemental & Concentration",
+        "id": "Federal",
         "type": "resource",
-        "total": 768554.46
+        "total": 196850.58
       },
       {
         "id": "General (Base)",
@@ -2919,9 +2919,9 @@
         "total": 3217448.92
       },
       {
-        "id": "Federal",
+        "id": "Supplemental & Concentration",
         "type": "resource",
-        "total": 196850.58
+        "total": 768554.46
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -3041,14 +3041,14 @@
     "site_code": 975,
     "nodes": [
       {
+        "id": "Federal",
+        "type": "resource",
+        "total": 1704912.84
+      },
+      {
         "id": "Philanthropy / Grants",
         "type": "resource",
         "total": 1098630.45
-      },
-      {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 1291760.59
       },
       {
         "id": "State",
@@ -3056,9 +3056,9 @@
         "total": 50302355.81
       },
       {
-        "id": "Federal",
+        "id": "Supplemental & Concentration",
         "type": "resource",
-        "total": 1704912.84
+        "total": 1291760.59
       },
       {
         "id": "CLASSSUPPT SALARIES",
@@ -3574,24 +3574,24 @@
     "site_code": 986,
     "nodes": [
       {
-        "id": "General (Base)",
-        "type": "resource",
-        "total": 5033529.59
-      },
-      {
         "id": "Bonds",
         "type": "resource",
         "total": 1554769.34
       },
       {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 228106.49
-      },
-      {
         "id": "Federal",
         "type": "resource",
         "total": 584320.9
+      },
+      {
+        "id": "General (Base)",
+        "type": "resource",
+        "total": 5033529.59
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 228106.49
       },
       {
         "id": "CLERICAL SALARIES",
@@ -3716,14 +3716,14 @@
     "site_code": 987,
     "nodes": [
       {
-        "id": "Other Revenue",
-        "type": "resource",
-        "total": 20262525.23
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 229379
+      },
+      {
+        "id": "Other Revenue",
+        "type": "resource",
+        "total": 20262525.23
       },
       {
         "id": "Computer $500-4,999",
@@ -4179,14 +4179,14 @@
         "total": 4587922.83
       },
       {
-        "id": "Philanthropy / Grants",
-        "type": "resource",
-        "total": 174191.47
-      },
-      {
         "id": "Other Revenue",
         "type": "resource",
         "total": 1100733.93
+      },
+      {
+        "id": "Philanthropy / Grants",
+        "type": "resource",
+        "total": 174191.47
       },
       {
         "id": "CLASSSUPPT SALARIES EXTRA COMP",
@@ -4550,14 +4550,14 @@
     "site_code": 995,
     "nodes": [
       {
-        "id": "State",
-        "type": "resource",
-        "total": 12617808.32
-      },
-      {
         "id": "General (Base)",
         "type": "resource",
         "total": 323713.37
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 12617808.32
       },
       {
         "id": "AUDIT EXPENSES",
@@ -4617,14 +4617,9 @@
     "site_code": 999,
     "nodes": [
       {
-        "id": "Philanthropy / Grants",
+        "id": "Federal",
         "type": "resource",
-        "total": 886044
-      },
-      {
-        "id": "Supplemental & Concentration",
-        "type": "resource",
-        "total": 7754674.29
+        "total": 712995.95
       },
       {
         "id": "General (Base)",
@@ -4637,19 +4632,24 @@
         "total": 805454.1
       },
       {
-        "id": "State",
-        "type": "resource",
-        "total": 2094903
-      },
-      {
         "id": "Parcel Taxes",
         "type": "resource",
         "total": 2685148.64
       },
       {
-        "id": "Federal",
+        "id": "Philanthropy / Grants",
         "type": "resource",
-        "total": 712995.95
+        "total": 886044
+      },
+      {
+        "id": "State",
+        "type": "resource",
+        "total": 2094903
+      },
+      {
+        "id": "Supplemental & Concentration",
+        "type": "resource",
+        "total": 7754674.29
       },
       {
         "id": "All Other Transfers to Districts or Charter Schools",

--- a/data/central-programs.json
+++ b/data/central-programs.json
@@ -1366,19 +1366,6 @@
     }
   },
   {
-    "code": 915,
-    "name": "Educator Effectiveness",
-    "category": "Instructional Programs",
-    "spending": 0,
-    "budget": 44281.54,
-    "year": 2019,
-    "eoy_total_fte": null,
-    "eoy_total_positions": null,
-    "remaining_budget_percent": 100,
-    "staff_roles": [],
-    "staff_bargaining_units": []
-  },
-  {
     "code": 923,
     "name": "Elementary Network 4",
     "category": "Instructional Programs",
@@ -2047,35 +2034,6 @@
     "remaining_budget_percent": 0,
     "staff_roles": [],
     "staff_bargaining_units": []
-  },
-  {
-    "code": 932,
-    "name": "Jr Reserve Officer Training Corp",
-    "category": "Instructional Programs",
-    "spending": 0,
-    "budget": 46905,
-    "year": 2019,
-    "eoy_total_fte": null,
-    "eoy_total_positions": null,
-    "remaining_budget_percent": 100,
-    "staff_roles": [],
-    "staff_bargaining_units": [],
-    "time_series": [
-      {
-        "year": 2018,
-        "eoy_total_fte": 0.25,
-        "eoy_total_positions": 1,
-        "spending": 19821.54,
-        "budget": 17074.9
-      }
-    ],
-    "change_from_previous_year": {
-      "previous_year": 2018,
-      "eoy_total_fte": -0.25,
-      "eoy_total_positions": -1,
-      "spending": -19821.54,
-      "budget": 29830.1
-    }
   },
   {
     "code": 942,
@@ -3178,19 +3136,6 @@
       "spending": -31471.17,
       "budget": -28531.53
     }
-  },
-  {
-    "code": 978,
-    "name": "Private Schools Office (Admin)",
-    "category": "Administrative Offices",
-    "spending": 0,
-    "budget": 0,
-    "year": 2019,
-    "eoy_total_fte": null,
-    "eoy_total_positions": null,
-    "remaining_budget_percent": null,
-    "staff_roles": [],
-    "staff_bargaining_units": []
   },
   {
     "code": 990,

--- a/data/sankey-restricted.json
+++ b/data/sankey-restricted.json
@@ -127,34 +127,9 @@
   ],
   "links": [
     {
-      "value": 1379665.59,
-      "target": "Special Education",
-      "source": "Unrestricted"
-    },
-    {
-      "value": 18641978.26,
-      "target": "Student Services",
+      "value": 5120335.12,
+      "target": "Administrative Offices",
       "source": "Restricted"
-    },
-    {
-      "value": 12573305.4,
-      "target": "Instructional Programs",
-      "source": "Unrestricted"
-    },
-    {
-      "value": 310649.73,
-      "target": "Financial Operations",
-      "source": "Restricted"
-    },
-    {
-      "value": 229379,
-      "target": "Risk Management",
-      "source": "Unrestricted"
-    },
-    {
-      "value": 17062845.64,
-      "target": "Other",
-      "source": "Unrestricted"
     },
     {
       "value": 11081840.2,
@@ -162,19 +137,9 @@
       "source": "Unrestricted"
     },
     {
-      "value": 2481635.3,
-      "target": "People Operations",
+      "value": 31300825.71,
+      "target": "Facilities",
       "source": "Restricted"
-    },
-    {
-      "value": 3535245.12,
-      "target": "Police",
-      "source": "Unrestricted"
-    },
-    {
-      "value": 10406371.43,
-      "target": "Other Operations",
-      "source": "Unrestricted"
     },
     {
       "value": 2486616.2,
@@ -182,28 +147,8 @@
       "source": "Unrestricted"
     },
     {
-      "value": 2874550.29,
-      "target": "Other Operations",
-      "source": "Restricted"
-    },
-    {
-      "value": 31300825.71,
-      "target": "Facilities",
-      "source": "Restricted"
-    },
-    {
-      "value": 6017695.79,
-      "target": "People Operations",
-      "source": "Unrestricted"
-    },
-    {
-      "value": 5120335.12,
-      "target": "Administrative Offices",
-      "source": "Restricted"
-    },
-    {
-      "value": 4284188.59,
-      "target": "Other",
+      "value": 310649.73,
+      "target": "Financial Operations",
       "source": "Restricted"
     },
     {
@@ -217,13 +162,68 @@
       "source": "Restricted"
     },
     {
+      "value": 12573305.4,
+      "target": "Instructional Programs",
+      "source": "Unrestricted"
+    },
+    {
+      "value": 4284188.59,
+      "target": "Other",
+      "source": "Restricted"
+    },
+    {
+      "value": 17062845.64,
+      "target": "Other",
+      "source": "Unrestricted"
+    },
+    {
+      "value": 2874550.29,
+      "target": "Other Operations",
+      "source": "Restricted"
+    },
+    {
+      "value": 10406371.43,
+      "target": "Other Operations",
+      "source": "Unrestricted"
+    },
+    {
+      "value": 2481635.3,
+      "target": "People Operations",
+      "source": "Restricted"
+    },
+    {
+      "value": 6017695.79,
+      "target": "People Operations",
+      "source": "Unrestricted"
+    },
+    {
+      "value": 3535245.12,
+      "target": "Police",
+      "source": "Unrestricted"
+    },
+    {
       "value": 20262525.23,
       "target": "Risk Management",
       "source": "Restricted"
     },
     {
+      "value": 229379,
+      "target": "Risk Management",
+      "source": "Unrestricted"
+    },
+    {
       "value": 53105899.1,
       "target": "Special Education",
+      "source": "Restricted"
+    },
+    {
+      "value": 1379665.59,
+      "target": "Special Education",
+      "source": "Unrestricted"
+    },
+    {
+      "value": 18641978.26,
+      "target": "Student Services",
       "source": "Restricted"
     },
     {
@@ -232,19 +232,9 @@
       "source": "Unrestricted"
     },
     {
-      "value": 44637359.11,
-      "target": "Unrestricted",
-      "source": "General (Base)"
-    },
-    {
-      "value": 31985013.2,
-      "target": "Unrestricted",
-      "source": "Supplemental & Concentration"
-    },
-    {
-      "value": 15664512.39,
-      "target": "Unrestricted",
-      "source": "State"
+      "value": 13185593.16,
+      "target": "Restricted",
+      "source": "Bonds"
     },
     {
       "value": 22092827.06,
@@ -252,9 +242,24 @@
       "source": "Federal"
     },
     {
+      "value": 44637359.11,
+      "target": "Unrestricted",
+      "source": "General (Base)"
+    },
+    {
       "value": 23643872.22,
       "target": "Restricted",
       "source": "Other Revenue"
+    },
+    {
+      "value": 1938920.67,
+      "target": "Unrestricted",
+      "source": "Other Revenue"
+    },
+    {
+      "value": 5799050.82,
+      "target": "Restricted",
+      "source": "Parcel Taxes"
     },
     {
       "value": 16342190.64,
@@ -267,19 +272,14 @@
       "source": "State"
     },
     {
-      "value": 13185593.16,
-      "target": "Restricted",
-      "source": "Bonds"
-    },
-    {
-      "value": 5799050.82,
-      "target": "Restricted",
-      "source": "Parcel Taxes"
-    },
-    {
-      "value": 1938920.67,
+      "value": 15664512.39,
       "target": "Unrestricted",
-      "source": "Other Revenue"
+      "source": "State"
+    },
+    {
+      "value": 31985013.2,
+      "target": "Unrestricted",
+      "source": "Supplemental & Concentration"
     }
   ]
 }

--- a/data/sankey.json
+++ b/data/sankey.json
@@ -117,173 +117,8 @@
   ],
   "links": [
     {
-      "value": 5149238.77,
-      "target": "Student Services",
-      "source": "Philanthropy / Grants"
-    },
-    {
-      "value": 170353.24,
-      "target": "People Operations",
-      "source": "Other Revenue"
-    },
-    {
-      "value": 953374.74,
-      "target": "Other Operations",
-      "source": "Federal"
-    },
-    {
-      "value": 2094903,
-      "target": "Other",
-      "source": "State"
-    },
-    {
-      "value": 6179251.67,
-      "target": "Student Services",
-      "source": "Supplemental & Concentration"
-    },
-    {
-      "value": 194289.22,
-      "target": "Administrative Offices",
-      "source": "State"
-    },
-    {
-      "value": 4919100.69,
-      "target": "Student Services",
-      "source": "General (Base)"
-    },
-    {
-      "value": 2685148.64,
-      "target": "Other",
-      "source": "Parcel Taxes"
-    },
-    {
-      "value": 189466.11,
-      "target": "Financial Operations",
-      "source": "Bonds"
-    },
-    {
-      "value": 712995.95,
-      "target": "Other",
-      "source": "Federal"
-    },
-    {
       "value": 3904349.91,
       "target": "Administrative Offices",
-      "source": "Federal"
-    },
-    {
-      "value": 19764242.34,
-      "target": "Facilities",
-      "source": "State"
-    },
-    {
-      "value": 5736680.32,
-      "target": "Financial Operations",
-      "source": "General (Base)"
-    },
-    {
-      "value": 2336974.16,
-      "target": "Instructional Programs",
-      "source": "Parcel Taxes"
-    },
-    {
-      "value": 2866044.33,
-      "target": "Student Services",
-      "source": "Other Revenue"
-    },
-    {
-      "value": 6245006.62,
-      "target": "Instructional Programs",
-      "source": "Federal"
-    },
-    {
-      "value": 432347.12,
-      "target": "People Operations",
-      "source": "Philanthropy / Grants"
-    },
-    {
-      "value": 1704912.84,
-      "target": "Special Education",
-      "source": "Federal"
-    },
-    {
-      "value": 1226963.02,
-      "target": "People Operations",
-      "source": "Supplemental & Concentration"
-    },
-    {
-      "value": 50302355.81,
-      "target": "Special Education",
-      "source": "State"
-    },
-    {
-      "value": 4790732.77,
-      "target": "People Operations",
-      "source": "General (Base)"
-    },
-    {
-      "value": 11862070.37,
-      "target": "Instructional Programs",
-      "source": "State"
-    },
-    {
-      "value": 886044,
-      "target": "Other",
-      "source": "Philanthropy / Grants"
-    },
-    {
-      "value": 2486616.2,
-      "target": "Facilities",
-      "source": "General (Base)"
-    },
-    {
-      "value": 8380120.88,
-      "target": "Other Operations",
-      "source": "General (Base)"
-    },
-    {
-      "value": 928336,
-      "target": "Administrative Offices",
-      "source": "Philanthropy / Grants"
-    },
-    {
-      "value": 2537253.81,
-      "target": "Police",
-      "source": "General (Base)"
-    },
-    {
-      "value": 11441357.71,
-      "target": "Facilities",
-      "source": "Bonds"
-    },
-    {
-      "value": 1554769.34,
-      "target": "Other Operations",
-      "source": "Bonds"
-    },
-    {
-      "value": 3545108.79,
-      "target": "Administrative Offices",
-      "source": "Supplemental & Concentration"
-    },
-    {
-      "value": 15183388.05,
-      "target": "Student Services",
-      "source": "State"
-    },
-    {
-      "value": 7754674.29,
-      "target": "Other",
-      "source": "Supplemental & Concentration"
-    },
-    {
-      "value": 20262525.23,
-      "target": "Risk Management",
-      "source": "Other Revenue"
-    },
-    {
-      "value": 8061115.43,
-      "target": "Student Services",
       "source": "Federal"
     },
     {
@@ -292,8 +127,128 @@
       "source": "General (Base)"
     },
     {
+      "value": 1226826.56,
+      "target": "Administrative Offices",
+      "source": "Other Revenue"
+    },
+    {
+      "value": 928336,
+      "target": "Administrative Offices",
+      "source": "Philanthropy / Grants"
+    },
+    {
+      "value": 194289.22,
+      "target": "Administrative Offices",
+      "source": "State"
+    },
+    {
+      "value": 3545108.79,
+      "target": "Administrative Offices",
+      "source": "Supplemental & Concentration"
+    },
+    {
+      "value": 11441357.71,
+      "target": "Facilities",
+      "source": "Bonds"
+    },
+    {
+      "value": 2486616.2,
+      "target": "Facilities",
+      "source": "General (Base)"
+    },
+    {
+      "value": 19764242.34,
+      "target": "Facilities",
+      "source": "State"
+    },
+    {
+      "value": 189466.11,
+      "target": "Financial Operations",
+      "source": "Bonds"
+    },
+    {
+      "value": 5736680.32,
+      "target": "Financial Operations",
+      "source": "General (Base)"
+    },
+    {
+      "value": 6245006.62,
+      "target": "Instructional Programs",
+      "source": "Federal"
+    },
+    {
+      "value": 2658491.35,
+      "target": "Instructional Programs",
+      "source": "General (Base)"
+    },
+    {
+      "value": 2336974.16,
+      "target": "Instructional Programs",
+      "source": "Parcel Taxes"
+    },
+    {
+      "value": 7488687.24,
+      "target": "Instructional Programs",
+      "source": "Philanthropy / Grants"
+    },
+    {
+      "value": 11862070.37,
+      "target": "Instructional Programs",
+      "source": "State"
+    },
+    {
+      "value": 8963012.98,
+      "target": "Instructional Programs",
+      "source": "Supplemental & Concentration"
+    },
+    {
+      "value": 712995.95,
+      "target": "Other",
+      "source": "Federal"
+    },
+    {
       "value": 6407814.25,
       "target": "Other",
+      "source": "General (Base)"
+    },
+    {
+      "value": 805454.1,
+      "target": "Other",
+      "source": "Other Revenue"
+    },
+    {
+      "value": 2685148.64,
+      "target": "Other",
+      "source": "Parcel Taxes"
+    },
+    {
+      "value": 886044,
+      "target": "Other",
+      "source": "Philanthropy / Grants"
+    },
+    {
+      "value": 2094903,
+      "target": "Other",
+      "source": "State"
+    },
+    {
+      "value": 7754674.29,
+      "target": "Other",
+      "source": "Supplemental & Concentration"
+    },
+    {
+      "value": 1554769.34,
+      "target": "Other Operations",
+      "source": "Bonds"
+    },
+    {
+      "value": 953374.74,
+      "target": "Other Operations",
+      "source": "Federal"
+    },
+    {
+      "value": 8380120.88,
+      "target": "Other Operations",
       "source": "General (Base)"
     },
     {
@@ -307,6 +262,46 @@
       "source": "Supplemental & Concentration"
     },
     {
+      "value": 453242.81,
+      "target": "People Operations",
+      "source": "Federal"
+    },
+    {
+      "value": 4790732.77,
+      "target": "People Operations",
+      "source": "General (Base)"
+    },
+    {
+      "value": 170353.24,
+      "target": "People Operations",
+      "source": "Other Revenue"
+    },
+    {
+      "value": 776928.02,
+      "target": "People Operations",
+      "source": "Parcel Taxes"
+    },
+    {
+      "value": 432347.12,
+      "target": "People Operations",
+      "source": "Philanthropy / Grants"
+    },
+    {
+      "value": 648764.11,
+      "target": "People Operations",
+      "source": "State"
+    },
+    {
+      "value": 1226963.02,
+      "target": "People Operations",
+      "source": "Supplemental & Concentration"
+    },
+    {
+      "value": 2537253.81,
+      "target": "Police",
+      "source": "General (Base)"
+    },
+    {
       "value": 997991.31,
       "target": "Police",
       "source": "Supplemental & Concentration"
@@ -317,44 +312,14 @@
       "source": "General (Base)"
     },
     {
-      "value": 805454.1,
-      "target": "Other",
+      "value": 20262525.23,
+      "target": "Risk Management",
       "source": "Other Revenue"
     },
     {
-      "value": 2658491.35,
-      "target": "Instructional Programs",
-      "source": "General (Base)"
-    },
-    {
-      "value": 1226826.56,
-      "target": "Administrative Offices",
-      "source": "Other Revenue"
-    },
-    {
-      "value": 648764.11,
-      "target": "People Operations",
-      "source": "State"
-    },
-    {
-      "value": 776928.02,
-      "target": "People Operations",
-      "source": "Parcel Taxes"
-    },
-    {
-      "value": 453242.81,
-      "target": "People Operations",
-      "source": "Federal"
-    },
-    {
-      "value": 7488687.24,
-      "target": "Instructional Programs",
-      "source": "Philanthropy / Grants"
-    },
-    {
-      "value": 1291760.59,
+      "value": 1704912.84,
       "target": "Special Education",
-      "source": "Supplemental & Concentration"
+      "source": "Federal"
     },
     {
       "value": 1098630.45,
@@ -362,8 +327,43 @@
       "source": "Philanthropy / Grants"
     },
     {
-      "value": 8963012.98,
-      "target": "Instructional Programs",
+      "value": 50302355.81,
+      "target": "Special Education",
+      "source": "State"
+    },
+    {
+      "value": 1291760.59,
+      "target": "Special Education",
+      "source": "Supplemental & Concentration"
+    },
+    {
+      "value": 8061115.43,
+      "target": "Student Services",
+      "source": "Federal"
+    },
+    {
+      "value": 4919100.69,
+      "target": "Student Services",
+      "source": "General (Base)"
+    },
+    {
+      "value": 2866044.33,
+      "target": "Student Services",
+      "source": "Other Revenue"
+    },
+    {
+      "value": 5149238.77,
+      "target": "Student Services",
+      "source": "Philanthropy / Grants"
+    },
+    {
+      "value": 15183388.05,
+      "target": "Student Services",
+      "source": "State"
+    },
+    {
+      "value": 6179251.67,
+      "target": "Student Services",
       "source": "Supplemental & Concentration"
     }
   ]


### PR DESCRIPTION
Refresh data against new query: https://github.com/openoakland/openousd-api/pull/13

I think only `data/central-programs.json` has material changes. The order of objects changed in the other JSON files for some reason.