### PR TITLE
add a component to generate program links

### DIFF
--- a/src/components/program-link.js
+++ b/src/components/program-link.js
@@ -1,0 +1,10 @@
+import React from "react"
+import { Link } from "gatsby-plugin-intl"
+import { useGetProgramPathBySiteCode } from "../utilities/get-program-path-by-site-code"
+
+const ProgramLink = ({ siteCode, children }) => {
+  const getProgramPathBySiteCode = useGetProgramPathBySiteCode()
+  return <Link to={getProgramPathBySiteCode(siteCode)}>{children}</Link>
+}
+
+export default ProgramLink

--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -10,6 +10,7 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 
 import { useLocalizeCategory } from "../utilities/content-utilities"
+import ProgramLink from "../components/program-link"
 
 import "../styles/pages/about-categories.scss"
 
@@ -61,6 +62,7 @@ const AboutCategoriesPage = ({ data, pageContext }) => {
         <Row>
           <Col md={8}>
             <div>
+              <ProgramLink siteCode="936">Accounting Program Link</ProgramLink>
               <div>{documentToReactComponents(introText.json)}</div>
             </div>
           </Col>

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -1,0 +1,32 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+export const useGetProgramPathBySiteCode = () => {
+	const allCentralProgramNodes = useStaticQuery(
+		graphql`
+			query {
+				allSitePage(
+					filter: {
+						context: { language: { eq: "en" } }
+						path: { regex: "/^(?!/en.*$).*/" }
+					}
+				) {
+					nodes {
+						path
+						context {
+							code
+						}
+					}
+				}
+			}
+		`
+	)
+	let pathsBySiteCode = {}
+
+	allCentralProgramNodes.allSitePage.nodes.forEach(program => {
+		pathsBySiteCode[program.context.code] = program.path
+	})
+
+	return siteCode => {
+		return pathsBySiteCode[siteCode]
+	}
+}

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -6,7 +6,7 @@ export const useGetProgramPathBySiteCode = () => {
 			query {
 				allSitePage(
 					filter: {
-						context: { language: { eq: "en" } }
+						context: { language: { eq: "en" }, code: { gt: 0 } }
 						path: { regex: "/^(?!/en.*$).*/" }
 					}
 				) {


### PR DESCRIPTION
Adds a new `ProgramLink` component that takes a `siteCode` prop and creates a localized Gatsby link.

For some reason, you're not allowed to put two static queries in one file. Otherwise this would be in `content-utilities.js`. Copied the pattern used there.

I added a path field to CentralProgramsJson because the queries were looking hacky without it.

Example usage on the About Categories page. Shouldn't be merged.