### PR TITLE
ProgramLink Component

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,5 @@
 const path = require(`path`)
-var slugify = require('slugify')
+var slugify = require("slugify")
 
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions
@@ -33,7 +33,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     // Some program names include parentheses, remove those so they don't end up in path
     const slugifyOptions = {
       remove: /[*+~.()'"!:@/]/g,
-      lower: true
+      lower: true,
     }
 
     const slug = slugify(node.name, slugifyOptions)
@@ -44,7 +44,15 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       node,
       value: slug,
     })
-  }}
+
+    // Use slug in path and create node field so it is queryable
+    createNodeField({
+      name: `path`,
+      node,
+      value: `central-programs/${slug}`,
+    })
+  }
+}
 
 exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions
@@ -56,7 +64,7 @@ exports.createPages = async ({ graphql, actions }) => {
           name
           code
           fields {
-            slug
+            path
           }
         }
       }
@@ -65,7 +73,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   result.data.allCentralProgramsJson.nodes.forEach(node => {
     createPage({
-      path: `central-programs/${node.fields.slug}`,
+      path: node.fields.path,
       component: path.resolve(`./src/components/central-program.js`),
       context: {
         // Data passed to context is available
@@ -73,4 +81,5 @@ exports.createPages = async ({ graphql, actions }) => {
         code: node.code,
       },
     })
-  })}
+  })
+}

--- a/src/components/central-program.js
+++ b/src/components/central-program.js
@@ -6,12 +6,14 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { Container, Row, Col } from "react-bootstrap"
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import { INLINES } from "@contentful/rich-text-types"
 
 import StaffRolesTable from "../components/central-program/staff-roles-table"
 import StaffLaborUnionsTable from "../components/central-program/staff-labor-unions-table"
 import ProgramDataOverviewTable from "../components/central-program/program-data-overview-table"
 import StaffLaborUnionsChart from "../components/central-program/staff-labor-unions-chart"
 import ScrollWidget from "../components/scroll-widget"
+import ProgramLink from "../components/program-link"
 
 import LaunchIcon from "@material-ui/icons/Launch"
 
@@ -21,6 +23,18 @@ import LaunchIcon from "@material-ui/icons/Launch"
 import "./central-program/central-program.scss"
 
 const ELEMENT_NAME_PREFIX = "program-section"
+
+const descriptionRenderOptions = {
+  renderNode: {
+    [INLINES.ENTRY_HYPERLINK]: (node, children) => {
+      return (
+        <ProgramLink siteCode={node.data.target.fields.siteCode.en}>
+          {children[0]}
+        </ProgramLink>
+      )
+    },
+  },
+}
 
 const CentralProgram = ({ data }) => {
   const centralProgram = data.centralProgramsJson
@@ -44,7 +58,10 @@ const CentralProgram = ({ data }) => {
             <Col md={9} xl={6} className="mx-auto">
               <div id={`${ELEMENT_NAME_PREFIX}-0`} className="pt-4">
                 <h1>{translatedProgramName}</h1>
-                {documentToReactComponents(contentfulProgramDescription)}
+                {documentToReactComponents(
+                  contentfulProgramDescription,
+                  descriptionRenderOptions
+                )}
                 {data.contentfulCentralProgram.OUSDProgramLink ? (
                   <div className="pt-3">
                     <a

--- a/src/components/program-link.js
+++ b/src/components/program-link.js
@@ -1,11 +1,17 @@
 import React from "react"
 import { Link } from "gatsby-plugin-intl"
+import PropTypes from "prop-types"
+
 import { useGetProgramPathBySiteCode } from "../utilities/get-program-path-by-site-code"
 
 const ProgramLink = ({ siteCode, children }) => {
-  return (
-    <Link to={`/${useGetProgramPathBySiteCode(siteCode)}`}>{children}</Link>
-  )
+	return (
+		<Link to={`/${useGetProgramPathBySiteCode(siteCode)}`}>{children}</Link>
+	)
+}
+
+ProgramLink.propTypes = {
+	data: PropTypes.number,
 }
 
 export default ProgramLink

--- a/src/components/program-link.js
+++ b/src/components/program-link.js
@@ -1,0 +1,10 @@
+import React from "react"
+import { Link } from "gatsby-plugin-intl"
+import { useGetProgramPathBySiteCode } from "../utilities/get-program-path-by-site-code"
+
+const ProgramLink = ({ siteCode, children }) => {
+  const getProgramPathBySiteCode = useGetProgramPathBySiteCode()
+  return <Link to={getProgramPathBySiteCode(siteCode)}>{children}</Link>
+}
+
+export default ProgramLink

--- a/src/components/program-link.js
+++ b/src/components/program-link.js
@@ -3,8 +3,9 @@ import { Link } from "gatsby-plugin-intl"
 import { useGetProgramPathBySiteCode } from "../utilities/get-program-path-by-site-code"
 
 const ProgramLink = ({ siteCode, children }) => {
-  const getProgramPathBySiteCode = useGetProgramPathBySiteCode()
-  return <Link to={`/${getProgramPathBySiteCode(siteCode)}`}>{children}</Link>
+  return (
+    <Link to={`/${useGetProgramPathBySiteCode(siteCode)}`}>{children}</Link>
+  )
 }
 
 export default ProgramLink

--- a/src/components/program-link.js
+++ b/src/components/program-link.js
@@ -4,7 +4,7 @@ import { useGetProgramPathBySiteCode } from "../utilities/get-program-path-by-si
 
 const ProgramLink = ({ siteCode, children }) => {
   const getProgramPathBySiteCode = useGetProgramPathBySiteCode()
-  return <Link to={getProgramPathBySiteCode(siteCode)}>{children}</Link>
+  return <Link to={`/${getProgramPathBySiteCode(siteCode)}`}>{children}</Link>
 }
 
 export default ProgramLink

--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -10,6 +10,7 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 
 import { useLocalizeCategory } from "../utilities/content-utilities"
+import ProgramLink from "../components/program-link"
 
 import "../styles/pages/about-categories.scss"
 
@@ -61,6 +62,7 @@ const AboutCategoriesPage = ({ data, pageContext }) => {
         <Row>
           <Col md={8}>
             <div>
+              <ProgramLink siteCode="936">Accounting Program Link</ProgramLink>
               <div>{documentToReactComponents(introText.json)}</div>
             </div>
           </Col>

--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -62,7 +62,6 @@ const AboutCategoriesPage = ({ data, pageContext }) => {
         <Row>
           <Col md={8}>
             <div>
-              <ProgramLink siteCode="936">Accounting Program Link</ProgramLink>
               <div>{documentToReactComponents(introText.json)}</div>
             </div>
           </Col>

--- a/src/pages/about-categories.js
+++ b/src/pages/about-categories.js
@@ -10,7 +10,6 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 
 import { useLocalizeCategory } from "../utilities/content-utilities"
-import ProgramLink from "../components/program-link"
 
 import "../styles/pages/about-categories.scss"
 

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -1,6 +1,7 @@
 import { useStaticQuery, graphql } from "gatsby"
+import { useMemo } from "react"
 
-export const useGetProgramPathBySiteCode = () => {
+export const useGetProgramPathBySiteCode = siteCode => {
   const allCentralProgramNodes = useStaticQuery(
     graphql`
       query {
@@ -15,13 +16,14 @@ export const useGetProgramPathBySiteCode = () => {
       }
     `
   )
-  let pathsBySiteCode = {}
 
-  allCentralProgramNodes.allCentralProgramsJson.nodes.forEach(program => {
-    pathsBySiteCode[program.code] = program.fields.path
-  })
+  const pathsBySiteCode = useMemo(() => {
+    const paths = {}
+    allCentralProgramNodes.allCentralProgramsJson.nodes.forEach(
+      program => (paths[program.code] = program.fields.path)
+    )
+    return paths
+  }, [allCentralProgramNodes])
 
-  return siteCode => {
-    return pathsBySiteCode[siteCode]
-  }
+  return pathsBySiteCode[siteCode]
 }

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -1,27 +1,27 @@
 import { useStaticQuery, graphql } from "gatsby"
 
 export const useGetProgramPathBySiteCode = () => {
-	const allCentralProgramNodes = useStaticQuery(
-		graphql`
-			query {
-				allCentralProgramsJson {
-					nodes {
-						code
-						fields {
-							path
-						}
-					}
-				}
-			}
-		`
-	)
-	let pathsBySiteCode = {}
+  const allCentralProgramNodes = useStaticQuery(
+    graphql`
+      query {
+        allCentralProgramsJson {
+          nodes {
+            code
+            fields {
+              path
+            }
+          }
+        }
+      }
+    `
+  )
+  let pathsBySiteCode = {}
 
-	allCentralProgramNodes.allCentralProgramsJson.nodes.forEach(program => {
-		pathsBySiteCode[program.code] = program.fields.path
-	})
+  allCentralProgramNodes.allCentralProgramsJson.nodes.forEach(program => {
+    pathsBySiteCode[program.code] = program.fields.path
+  })
 
-	return siteCode => {
-		return pathsBySiteCode[siteCode]
-	}
+  return siteCode => {
+    return pathsBySiteCode[siteCode]
+  }
 }

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -1,0 +1,32 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+export const useGetProgramPathBySiteCode = () => {
+	const allCentralProgramNodes = useStaticQuery(
+		graphql`
+			query {
+				allSitePage(
+					filter: {
+						context: { language: { eq: "en" } }
+						path: { regex: "/^(?!/en.*$).*/" }
+					}
+				) {
+					nodes {
+						path
+						context {
+							code
+						}
+					}
+				}
+			}
+		`
+	)
+	let pathsBySiteCode = {}
+
+	allCentralProgramNodes.allSitePage.nodes.forEach(program => {
+		pathsBySiteCode[program.context.code] = program.path
+	})
+
+	return siteCode => {
+		return pathsBySiteCode[siteCode]
+	}
+}

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -4,16 +4,11 @@ export const useGetProgramPathBySiteCode = () => {
 	const allCentralProgramNodes = useStaticQuery(
 		graphql`
 			query {
-				allSitePage(
-					filter: {
-						context: { language: { eq: "en" }, code: { gt: 0 } }
-						path: { regex: "/^(?!/en.*$).*/" }
-					}
-				) {
+				allCentralProgramsJson {
 					nodes {
-						path
-						context {
-							code
+						code
+						fields {
+							path
 						}
 					}
 				}
@@ -22,8 +17,8 @@ export const useGetProgramPathBySiteCode = () => {
 	)
 	let pathsBySiteCode = {}
 
-	allCentralProgramNodes.allSitePage.nodes.forEach(program => {
-		pathsBySiteCode[program.context.code] = program.path
+	allCentralProgramNodes.allCentralProgramsJson.nodes.forEach(program => {
+		pathsBySiteCode[program.code] = program.fields.path
 	})
 
 	return siteCode => {

--- a/src/utilities/get-program-path-by-site-code.js
+++ b/src/utilities/get-program-path-by-site-code.js
@@ -6,7 +6,7 @@ export const useGetProgramPathBySiteCode = () => {
 			query {
 				allSitePage(
 					filter: {
-						context: { language: { eq: "en" } }
+						context: { language: { eq: "en" }, code: { gt: 0 } }
 						path: { regex: "/^(?!/en.*$).*/" }
 					}
 				) {


### PR DESCRIPTION
Adds a new `ProgramLink` component that takes a `siteCode` prop and creates a localized Gatsby link.

For some reason, you're not allowed to put two static queries in one file. Otherwise this would be in `content-utilities.js`. Copied the pattern used there.

I added a path field to CentralProgramsJson because the queries were looking hacky without it.

Example usage on the About Categories page. Shouldn't be merged.