### PR TITLE
Hide radial labels / Use a string in Contentful instead of embedded entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "devDependencies": {
     "gh-pages": "^2.2.0",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "keywords": [
     "gatsby"

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,50 +1,117 @@
 import React from "react"
-import { Link, FormattedMessage } from 'gatsby-plugin-intl'
-import { Navbar, Nav, Container } from 'react-bootstrap'
+import { useStaticQuery, graphql } from "gatsby"
+import { IntlContextConsumer, Link } from "gatsby-plugin-intl"
 
-import LanguagePicker from './language-picker'
+import { Navbar, Nav, Container } from "react-bootstrap"
+
+import LanguagePicker from "./language-picker"
 import "./header.scss"
 import logo from "../images/oo-logo-combined.svg"
 
-
-const Header = ({ siteTitle }) => (
+const Header = ({ siteTitle }) => {
+  const {
+    allContentfulNavigation: { nodes: navigationsByLanguage },
+  } = useStaticQuery(
+    graphql`
+      query {
+        allContentfulNavigation {
+          nodes {
+            navItems {
+              slug
+              navigationTitle
+            }
+            node_locale
+            tagline {
+              tagline
+            }
+          }
+        }
+      }
+    `
+  )
+  return (
     // Nasty fragment, but sticky positioning doesn't work within nonstandard tags?
     // https://github.com/twbs/bootstrap/issues/21919
-    <>
-        <Container className="header">
-            <Navbar bg="white" variant="light" expand="md" className="d-flex flex-column">
-                <div id="logo-row" className="d-flex flex-column flex-lg-row align-items-center justify-content-lg-between">
-                    <div id="logo">
-                        <Link to="/"><img src={logo} alt="Open OUSD and OpenOakland logos" /></Link>
-                    </div>
-                    <div id="tagline" className="text-center text-lg-right pt-2">
-                        <FormattedMessage id="navigation.tagline"/>
-                    </div>
+
+    <IntlContextConsumer>
+      {({ languages, language: currentLocale }) => {
+        const {
+          navItems,
+          tagline: { tagline },
+        } = navigationsByLanguage.find(nav => nav.node_locale === currentLocale)
+        return (
+          <>
+            <Container className="header">
+              <Navbar
+                bg="white"
+                variant="light"
+                expand="md"
+                className="d-flex flex-column"
+              >
+                <div
+                  id="logo-row"
+                  className="d-flex flex-column flex-lg-row align-items-center justify-content-lg-between"
+                >
+                  <div id="logo">
+                    <Link to="/">
+                      <img src={logo} alt="Open OUSD and OpenOakland logos" />
+                    </Link>
+                  </div>
+                  <div id="tagline" className="text-center text-lg-right pt-2">
+                    {tagline}
+                  </div>
                 </div>
-            </Navbar>
-        </Container>
-
-        <Navbar bg="white" variant="light" expand="md" sticky="top" id="menu-row">
-            <Navbar.Toggle aria-controls="basic-navbar-nav" />
-            <Navbar.Collapse id="basic-navbar-nav" className="sticky-top">
+              </Navbar>
+            </Container>
+            <Navbar
+              bg="white"
+              variant="light"
+              expand="md"
+              sticky="top"
+              id="menu-row"
+            >
+              <Navbar.Toggle aria-controls="basic-navbar-nav" />
+              <Navbar.Collapse id="basic-navbar-nav" className="sticky-top">
                 <Nav className="menu mx-auto flex-nowrap d-flex flex-column">
-                    <hr className="d-none d-md-block"/>
-                    <div id="menu-items" className="d-flex flex-column flex-md-row mt-3 mt-md-0">
-                        <Nav.Item><Link to="/" activeClassName="active"><span className="d-none d-md-block"><span className="dot"/></span><FormattedMessage id="navigation.index"/></Link></Nav.Item>
-                        <Nav.Item><Link to="/central-programs/" activeClassName="active"><span className="d-none d-md-block"><span className="dot"/></span><FormattedMessage id="navigation.central-programs"/></Link></Nav.Item>
-                        <Nav.Item><Link to="/contact/" activeClassName="active"><span className="d-none d-md-block"><span className="dot"/></span><FormattedMessage id="navigation.contact"/></Link></Nav.Item>
-                        <LanguagePicker className="d-none d-md-block pr-3"/>
-                    </div>
+                  <hr className="d-none d-md-block" />
+                  <div
+                    id="menu-items"
+                    className="d-flex flex-column flex-md-row mt-3 mt-md-0"
+                  >
+                    {navItems.map(navItem => {
+                      // Small hack for the home page since we use `index` to identify it in
+                      // Contentful but it's slug is the empty string
+                      const slug = navItem.slug === "index" ? "" : navItem.slug
+                      return (
+                        <Nav.Item>
+                          <Link to={`/${slug}`} activeClassName="active">
+                            <span className="d-none d-md-block">
+                              <span className="dot" />
+                            </span>
+                            {navItem.navigationTitle}
+                          </Link>
+                        </Nav.Item>
+                      )
+                    })}
+                    <LanguagePicker className="d-none d-md-block pr-3" />
+                  </div>
                 </Nav>
-            </Navbar.Collapse>
-            <LanguagePicker className="d-md-none pr-3"/>
-        </Navbar>
-    </>
-)
-
-Header.defaultProps = {
-    siteTitle: ``,
+              </Navbar.Collapse>
+              <LanguagePicker
+                languages={languages}
+                currentLocale={currentLocale}
+                className="d-md-none pr-3"
+              />
+            </Navbar>
+          </>
+        )
+      }}
+    </IntlContextConsumer>
+  )
 }
 
+Header.defaultProps = {
+  siteTitle: ``,
+}
 
 export default Header

--- a/src/components/language-picker.js
+++ b/src/components/language-picker.js
@@ -1,38 +1,48 @@
-import React from 'react'
-import { IntlContextConsumer, changeLocale } from 'gatsby-plugin-intl'
-import { NavDropdown } from 'react-bootstrap'
-import changeLanguageIcon from '../images/icons/ic_change-language.svg'
-
+import React from "react"
+import { IntlContextConsumer, changeLocale } from "gatsby-plugin-intl"
+import { NavDropdown } from "react-bootstrap"
+import changeLanguageIcon from "../images/icons/ic_change-language.svg"
 
 const languageName = {
   en: "English",
   es: "Español",
 }
 
-const LanguagePicker = (props) => {
+const LanguagePicker = props => {
+  const ChangeLanguageIcon = () => (
+    <img
+      className="change-language-icon"
+      src={changeLanguageIcon}
+      alt="icon of language characters"
+    />
+  )
 
-    const ChangeLanguageIcon = () =>
-      (<img className="change-language-icon" src={changeLanguageIcon} alt="icon of language characters"/>)
-
-    return (
-        <div className="language-picker">
-            <IntlContextConsumer>
-                {({ languages, language: currentLocale }) => (
-                    <NavDropdown alignRight className={props.className} title={<span><ChangeLanguageIcon/> {languageName[currentLocale]}</span>}>
-                    {languages.map(language => (
-                        <NavDropdown.Item
-                          key={language}
-                          onClick={() => changeLocale(language)}
-                        >
-                          {languageName[language]}
-                        </NavDropdown.Item>
-                    ))}
-                    </NavDropdown>
-                )
-                }
-            </IntlContextConsumer>
-        </div>
-    )
+  return (
+    <div className="language-picker">
+      <IntlContextConsumer>
+        {({ languages, language: currentLocale }) => (
+          <NavDropdown
+            alignRight
+            className={props.className}
+            title={
+              <span>
+                <ChangeLanguageIcon /> {languageName[currentLocale]}
+              </span>
+            }
+          >
+            {languages.map(language => (
+              <NavDropdown.Item
+                key={language}
+                onClick={() => changeLocale(language)}
+              >
+                {languageName[language]}
+              </NavDropdown.Item>
+            ))}
+          </NavDropdown>
+        )}
+      </IntlContextConsumer>
+    </div>
+  )
 }
 
 export default LanguagePicker

--- a/src/components/new-feature.js
+++ b/src/components/new-feature.js
@@ -9,7 +9,13 @@ const NewFeature = props => {
     <div className="mt-4">
       <h3>{props.heading}</h3>
       <div>{props.date}</div>
-      <img src={props.image} alt={props.image_titles} className="mw-100 pt-3" />
+      <Link to={props.pagePath}>
+        <img
+          src={props.image}
+          alt={props.image_titles}
+          className="mw-100 pt-3 border"
+        />
+      </Link>
       <div className="pt-3">{props.description}</div>
       {props.pagePath ? (
         <div className="pt-3">

--- a/src/components/pie-chart.js
+++ b/src/components/pie-chart.js
@@ -7,9 +7,18 @@ import ArrowDropDown from "@material-ui/icons/ArrowDropDown"
 import ArrowDropUp from "@material-ui/icons/ArrowDropUp"
 import Person from "@material-ui/icons/Person"
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
-import { BLOCKS, MARKS } from "@contentful/rich-text-types"
+import { MARKS } from "@contentful/rich-text-types"
 import { formatToUSD } from "../components/table-utilities"
 import "./pie-chart.scss"
+
+const contentPaths = {
+  centralProgramsLabel: "centralProgramsLabel",
+  otherLabel: "otherLabel",
+  description: "description.json",
+  statDescriptor: "statDescriptor",
+  increaseDescriptor: "increaseDescriptor",
+  decreaseDescriptor: "decreaseDescriptor",
+}
 
 function getObjValueFromPath(path) {
   const keyRegex = "[a-zA-Z_$]\\w*"
@@ -89,23 +98,20 @@ const Description = ({ percentOfTotal, data, content, formatValue }) => {
               ? content.increaseDescriptor
               : content.decreaseDescriptor
           return <strong>{changeDescriptor}</strong>
+        } else if (text === "**Change Quantity**") {
+          return (
+            <span className="change pt-2">
+              {data.change < 0 ? (
+                <ArrowDropDown className="arrow" alt="down arrow" />
+              ) : (
+                <ArrowDropUp className="arrow" alt="up arrow" />
+              )}{" "}
+              {formatValue(Math.abs(data.change))}
+            </span>
+          )
         } else {
           return <strong>{text}</strong>
         }
-      },
-    },
-    renderNode: {
-      [BLOCKS.EMBEDDED_ENTRY]: (node, children) => {
-        return (
-          <div className="change pb-2 pt-2">
-            {data.change < 0 ? (
-              <ArrowDropDown className="arrow" alt="down arrow" />
-            ) : (
-              <ArrowDropUp className="arrow" alt="up arrow" />
-            )}{" "}
-            {formatValue(Math.abs(data.change))}
-          </div>
-        )
       },
     },
   }
@@ -218,14 +224,7 @@ export const SpendingPieChart = ({ data, content }) => {
     allOUSD: "all_ousd_spending",
     change: "change_from_previous_year.spending",
   }
-  const contentPaths = {
-    centralProgramsLabel: "centralProgramsLabel",
-    otherLabel: "otherLabel",
-    description: "description.json",
-    statDescriptor: "statDescriptor",
-    increaseDescriptor: "increaseDescriptor",
-    decreaseDescriptor: "decreaseDescriptor",
-  }
+
   const parsedData = parseObject(data, dataPaths)
   const contentToParse = content.find(({ name }) => name === "Spending")
   const parsedContent = parseObject(contentToParse, contentPaths)
@@ -264,14 +263,7 @@ export const StaffPieChart = ({ data, content }) => {
     allOUSD: "all_ousd_eoy_total_positions",
     change: "change_from_previous_year.eoy_total_positions",
   }
-  const contentPaths = {
-    centralProgramsLabel: "centralProgramsLabel",
-    otherLabel: "otherLabel",
-    description: "description.json",
-    statDescriptor: "statDescriptor",
-    increaseDescriptor: "increaseDescriptor",
-    decreaseDescriptor: "decreaseDescriptor",
-  }
+
   const contentToParse = content.find(({ name }) => name === "Staff")
   const parsedData = parseObject(data, dataPaths)
   const parsedContent = parseObject(contentToParse, contentPaths)

--- a/src/components/pie-chart.js
+++ b/src/components/pie-chart.js
@@ -1,6 +1,7 @@
-import React, { useState, useMemo, /*useCallback*/ } from "react"
+import React, { useState, useMemo, useCallback } from "react"
 
 import { ResponsivePie } from "@nivo/pie"
+import ResizeObserver from "resize-observer-polyfill"
 
 import ArrowDropDown from "@material-ui/icons/ArrowDropDown"
 import ArrowDropUp from "@material-ui/icons/ArrowDropUp"
@@ -29,7 +30,7 @@ const parseObject = (objectToParse, paths) => {
   return result
 }
 
-/*const useResizeObserverRef = callback => {
+const useResizeObserverRef = callback => {
   const resizeObserver = useMemo(() => new ResizeObserver(callback), [callback])
   const ref = useCallback(
     node => {
@@ -38,7 +39,7 @@ const parseObject = (objectToParse, paths) => {
     [resizeObserver]
   )
   return ref
-}*/
+}
 
 const CenteredMetric = ({ descriptor, icon, percentOfTotal }) => ({
   dataWithArc,
@@ -127,13 +128,13 @@ const CentralToTotalComparisonPie = ({
   const [activeNode, setActiveNode] = useState(null)
   const [showRadialLabels, setShowRadialLabels] = useState(true)
 
-/*  const radialLabelSizeCheck = useCallback(
+  const radialLabelSizeCheck = useCallback(
     ([entry]) => {
       setShowRadialLabels(entry.contentRect.width > 470)
     },
     [setShowRadialLabels]
   )
-  const labelRef = useResizeObserverRef(radialLabelSizeCheck)*/
+  const labelRef = useResizeObserverRef(radialLabelSizeCheck)
 
   const percentOfTotal = Math.floor((data.centralPrograms / data.allOUSD) * 100)
 
@@ -163,7 +164,7 @@ const CentralToTotalComparisonPie = ({
 
   return (
     <div className="overview-chart">
-      <div className="pie-chart" /*ref={labelRef}*/>
+      <div className="pie-chart" ref={labelRef}>
         <ResponsivePie
           data={pieChartData}
           colors={({ data: { color } }) => color}

--- a/src/components/pie-chart.scss
+++ b/src/components/pie-chart.scss
@@ -15,10 +15,11 @@
     max-width: 310px;
     margin: 0 auto 16px auto;
     text-align: center;
-    p{
+    p {
       margin: 0;
     }
     .change {
+      display: block;
       font-size: 1.8em;
       margin-left: -15px;
       .arrow {

--- a/src/pages/central-programs.js
+++ b/src/pages/central-programs.js
@@ -9,7 +9,7 @@ import SEO from "../components/seo"
 import RequireWideScreen from "../components/require-wide-screen"
 import CentralProgramsTable from "../components/central-programs-table"
 import SankeyChart from "../components/sankey-chart"
-import {SpendingPieChart, StaffPieChart} from "../components/pie-chart"
+import { SpendingPieChart, StaffPieChart } from "../components/pie-chart"
 
 import sankeyProgramData from "../../data/sankey.json"
 import sankeyRestrictedProgramData from "../../data/sankey-restricted.json"
@@ -22,7 +22,9 @@ const CentralProgramsPage = ({ data, pageContext }) => {
   const centralProgramsOverviewData = data.centralProgramsOverviewJson
   let centralPrograms = data.allCentralProgramsJson.nodes
   const content = data.contentfulPage.content
-  Object.assign(content, { contentfulPie: data.allContentfulOverviewPieChart.nodes })
+  Object.assign(content, {
+    contentfulPie: data.allContentfulOverviewPieChart.nodes,
+  })
   const translatedProgramNames = data.allContentfulCentralProgram.nodes
   const localizeCategory = useLocalizeCategory(pageContext.language)
 

--- a/src/pages/whats-new.js
+++ b/src/pages/whats-new.js
@@ -20,26 +20,6 @@ const getNestedObject = (nestedObj, pathArr) => {
   )
 }
 
-//  formatting date from Contenful, 2020-06-03 => June 3, 2020
-const dateToString = (date, locale) => {
-  var mydate = new Date(date)
-  const options = { month: "long", day: "numeric" }
-
-  const mydateEN = mydate.toLocaleDateString("en-US", options)
-  const resultES = mydate.toLocaleDateString("es-ES", options)
-
-  //time in ES
-  const mydateES = resultES
-    .replace(/([^\W_]+[^\s-]*) */g, function(txt) {
-      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-    })
-    .replace(/\bDe\b/g, function(txt) {
-      return txt.toLowerCase()
-    })
-
-  return (locale === "en" ? mydateEN : mydateES) + ", " + mydate.getFullYear()
-}
-
 // formatting the date (June 3, 2020) into an id that react scroll can reference (#june-3-2020)
 const dateToDivID = date => {
   return "#" + date.replace(/[\W_]+/g, "-").toLowerCase()
@@ -53,9 +33,18 @@ const options = {
   },
 }
 
-const WhatsNewPage = ({ data }) => {
+const WhatsNewPage = ({ data, pageContext }) => {
   const { title, node_locale } = data.contentfulPage
   const changelog = data.allContentfulChangelogContent.nodes
+
+  //  formatting date from Contenful, 2020-06-03 => June 3, 2020
+  const dateToString = (date, locale) => {
+    let mydate = new Date(date)
+    const options = { month: "long", day: "numeric", year: "numeric" }
+
+    return mydate.toLocaleDateString(pageContext.language, options)
+  }
+
   return (
     <Layout pageClassName="whats-new-page">
       <SEO title={title} />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,8 +1,0 @@
-{
-    "navigation": {
-        "index": "Home",
-        "central-programs": "Central Programs",
-        "contact": "Contact",
-        "tagline": "Volunteers providing transparent access to the Oakland Unified School District's central office"
-    }
-}

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -1,8 +1,0 @@
-{
-    "navigation": {
-        "index": "Inicio",
-        "central-programs": "Programas Centrales",
-        "contact": "Contacto",
-        "tagline": "Voluntarios que brindan acceso transparente a la sede del Distrito Escolar Unificado de Oakland"
-    }
-}


### PR DESCRIPTION
ResizeObserver works in the Gastby production build with the polyfill

Prefer to use the string rather than embed content type just because Contentful limits the number of content types you can have. We're not near the limit but just feels worth conserving as we go.

![Screen Shot 2021-05-15 at 7 32 49 PM](https://user-images.githubusercontent.com/1191015/118383609-5af9e780-b5b4-11eb-9819-d4955fa5a9db.png)