### PR TITLE
Docker npm install fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:14-buster
 
+COPY package.json package-lock.json /openousd
+
 WORKDIR "/openousd"
 
-RUN npm install --global gatsby-cli
+RUN npm install --global gatsby-cli@3.14.0
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:14-buster
 
-COPY package.json package-lock.json /openousd
-
-WORKDIR "/openousd"
+WORKDIR /openousd
+COPY package*.json ./
 
 RUN npm install --global gatsby-cli@3.14.0
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Go to `http://localhost:8000` in your browser
 
 TODO: may need to delete the volume and recreate the container if you want to updte package.json / containers or look into using the `--renew-anon-volumes` flag.
 
+Cleaning out old containers
+
+1. run the script `./cleanDocker.sh`
+2. enter `y` to prune volumes when prompted
+
+
 See: https://stackoverflow.com/questions/30043872/docker-compose-node-modules-not-present-in-a-volume-after-npm-install-succeeds
 
 ## Deploying

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ echo "CONTENTFUL_ACCESS_TOKEN={insert the token here and remove brackets}" > .en
 
 Go to `http://localhost:8000` in your browser
 
+### Using docker
+
+**Initial setup:**
+1. `docker-compose up`
+2. `docker-compose run gatsby`
+3. `npm install`
+
+From then on, use
+1. `docker-compose run gatsby`
+2. `npm start`
+
 ## Deploying
 
 ### Staging

--- a/README.md
+++ b/README.md
@@ -30,14 +30,11 @@ Go to `http://localhost:8000` in your browser
 
 ### Using docker
 
-**Initial setup:**
-1. `docker-compose up`
-2. `docker-compose run gatsby`
-3. `npm install`
+`docker-compose up`
 
-From then on, use
-1. `docker-compose run gatsby`
-2. `npm start`
+TODO: may need to delete the volume and recreate the container if you want to updte package.json / containers or look into using the `--renew-anon-volumes` flag.
+
+See: https://stackoverflow.com/questions/30043872/docker-compose-node-modules-not-present-in-a-volume-after-npm-install-succeeds
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Go to `http://localhost:8000` in your browser
 
 ### Using docker
 
+**Setup**
+
 `docker-compose up`
 
 TODO: may need to delete the volume and recreate the container if you want to updte package.json / containers or look into using the `--renew-anon-volumes` flag.
 
-Cleaning out old containers
+**Cleaning out old containers**
 
 1. run the script `./cleanDocker.sh`
 2. enter `y` to prune volumes when prompted

--- a/cleanDocker.sh
+++ b/cleanDocker.sh
@@ -1,0 +1,5 @@
+docker rm $(docker ps -aq --filter ancestor=openousd-site_gatsby)
+
+docker volume prune
+
+docker rmi openousd-site_gatsby

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,10 +4,12 @@ services:
   gatsby:
     ports:
       - "8000:8000"
-    build: .
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     volumes:
       - .:/openousd
+      - /openousd/node_modules #https://justlike.medium.com/how-to-avoid-overriding-node-modules-in-docker-for-local-development-20f412444589
     stdin_open: true
     tty: true
     command: "gatsby develop -H 0.0.0.0 -p 8000"
-    # entrypoint: /bin/sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,5 +8,6 @@ services:
     volumes:
       - .:/openousd
     stdin_open: true
-    tty: true 
+    tty: true
     command: "gatsby develop -H 0.0.0.0 -p 8000"
+    # entrypoint: /bin/sh

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop -H 0.0.0.0 -p 8000",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
Docker setup wasn't working properly because it required doing an `npm install` on the host. This fix makes sure it happens in the container and is not overwritten so that node_modules are fetched there. It may make it difficult to update dependencies in the future. There may be a better way, but this is working for now.

Also added a script for cleaning out old containers. `cleanDocker.sh` 