### PR TITLE
change docker base image to avoid sharp dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster
+FROM node:14-bullseye
 
 WORKDIR /openousd
 COPY package*.json ./


### PR DESCRIPTION
This is a bit of a hack because I'm not updating anything and building the site may still be broken outside of docker.

Via this thread https://github.com/lovell/sharp/issues/2482, I basically found that I was using an older version of glibc via debian buster. In the issue, there is mention of things working with bullseye, so I changed to node bullseye. 

I tried to jump up to node 20 and got a build error, so just sticking with node 14 for now.